### PR TITLE
Update apt package list

### DIFF
--- a/INSTALL/libraries.sh
+++ b/INSTALL/libraries.sh
@@ -8,6 +8,7 @@ python3.6 -m pip install --user zstandard
 python3.6 -m pip install --user tqdm
 
 # Install tre regexp-up-to-edit-distance library
+sudo apt-get update
 sudo apt-get install --yes agrep libtre-dev git
 git clone https://github.com/ahomansikka/tre
 (

--- a/INSTALL/python.sh
+++ b/INSTALL/python.sh
@@ -5,6 +5,7 @@ set -e -u -o pipefail
 
 cat /etc/lsb-release  # Just to see which Ubuntu version we're on
 
+sudo apt-get update
 sudo apt-get install --yes curl
 sudo apt-get install --yes software-properties-common # for add-apt-repository
 


### PR DESCRIPTION
Hopefully addresses #3 :pray: 

`apt update` downloads a fresh list of available packages.
Running `apt install` with outdated list may fail with `404  Not Found` as the local list points to a version which is no longer available.

(The tests with Dockerfile-* didn't catch this because the Dockerfiles themselves do `apt-get update` early in order to install `sudo`.  But ALL.sh didn't :-)

@anpc please review.
